### PR TITLE
Adding support for multiple status values to fix apache issues

### DIFF
--- a/docs/YAMLFormat.md
+++ b/docs/YAMLFormat.md
@@ -368,7 +368,7 @@ Status
 -----------
 **Description**: Checks the response code of the response to see if it matches the provided value
 
-**Syntax:** ```status: <integer>```
+**Syntax:** ```status: <integer>|<integer list>```
 
 **Example Usage:** ```status: 200```
 

--- a/ftw/ruleset.py
+++ b/ftw/ruleset.py
@@ -24,8 +24,27 @@ class Output(object):
                 }
             )
         self.output_dict = output_dict
-        self.status = int(output_dict[self.STATUS]) \
-            if self.STATUS in self.output_dict else None
+        skip_checks = False
+        if self.STATUS not in self.output_dict:
+            skip_checks = True
+        if skip_checks is False and isinstance(output_dict[self.STATUS],list):
+            # Check the number of integers in the list
+            num_ele = len([s for s in output_dict[self.STATUS] if type(s) is int])
+            # If all elements are integers, we're good
+            if len(output_dict[self.STATUS]) == num_ele:
+                self.status = output_dict[self.STATUS]
+            else:
+                raise errors.TestError(
+                    'Non integers found in Status list',
+                    {
+                        'status': output_dict[self.STATUS],
+                        'function': 'ruleset.Output.__init__'
+                    }
+                )
+        elif skip_checks is False and isinstance(output_dict[self.STATUS],int):
+            self.status = int(output_dict[self.STATUS])
+        else:
+            self.status = None
         self.response_contains_str = self.process_regex(self.RESPONSE)
         self.no_log_contains_str = self.process_regex(self.NOTLOG)
         self.log_contains_str = self.process_regex(self.LOG)

--- a/ftw/testrunner.py
+++ b/ftw/testrunner.py
@@ -20,7 +20,10 @@ class TestRunner(object):
         Compares the expected output against actual output of test and stage
         In a separate function to make debugging easy with py.test
         """
-        assert expected_status == actual_status
+        if type(expected_status) is list:
+            assert actual_status in expected_status
+        else:
+            assert expected_status == actual_status
 
     def test_log(self, lines, log_contains, negate):
         """

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@
 from setuptools import setup
 
 setup(name='ftw',
-      version='1.1.4',
+      version='1.1.5',
       description='Framework for Testing WAFs',
       author='Chaim Sanders, Zack Allen',
       author_email='zma4580@gmail.com, chaim.sanders@gmail.com',
       url='https://www.github.com/crs-support/ftw',
-      download_url='https://github.com/crs-support/ftw/tarball/1.1.4',
+      download_url='https://github.com/crs-support/ftw/tarball/1.1.5',
       include_package_data=True,
       package_data={
         'ftw': ['util/public_suffix_list.dat']

--- a/test/unit/test_ruleset.py
+++ b/test/unit/test_ruleset.py
@@ -5,13 +5,16 @@ def test_output():
     with pytest.raises(errors.TestError) as excinfo:
         output = ruleset.Output({})
     assert(excinfo.value.args[0].startswith('Need at least'))
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(errors.TestError) as excinfo:
         output = ruleset.Output({'status': 'derp'})
-    assert(excinfo.value.message.startswith('invalid literal'))
-
+    assert(excinfo.value.args[0].startswith('Need at least'))
     with pytest.raises(TypeError) as excinfo:
         output = ruleset.Output({'log_contains': 10})
-
+    output = ruleset.Output({'status': 200}) 
+    output = ruleset.Output({'status': [100,200]})
+    with pytest.raises(errors.TestError) as excinfo:
+        output = ruleset.Output({'status': [100,'derp']})
+    assert(excinfo.value.args[0].startswith('Non integers found'))
 def test_input():
     input_1 = ruleset.Input()
     assert(input_1.uri == '/')


### PR DESCRIPTION
For OWASP CRS we need support for multiple status codes so that if Apache fails  and returns a 400 before CRS is hit we can support the check still on other webservers.