### PR TITLE
Fix loading issue with python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,6 @@ script:
   - py.test test/integration/test_cookie.py --rule=test/integration/COOKIEFIXTURE.yaml
   - py.test test/integration/test_runner.py --rule=test/integration/MULTIPART.yaml
   - py.test test/integration/test_runner.py --rule=test/integration/EXPECTERRORFIXTURE.yaml
+  - py.test test/integration/test_runner.py --rule=test/integration/BASICFIXTURE.yaml
   - py.test --pycodestyle ftw || true
   - py.test --flakes ftw

--- a/ftw/util.py
+++ b/ftw/util.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import io
 import yaml
 import os
 import sqlite3
@@ -85,7 +86,7 @@ def extract_yaml(yaml_files):
     loaded_yaml = []
     for yaml_file in yaml_files:
         try:
-            with open(yaml_file, 'r') as fd:
+            with io.open(yaml_file, encoding='utf-8') as fd:
                 loaded_yaml.append(yaml.safe_load(fd))
         except IOError as e:
             print('Error reading file', yaml_file)

--- a/test/integration/BASICFIXTURE.yaml
+++ b/test/integration/BASICFIXTURE.yaml
@@ -1,0 +1,19 @@
+---
+  meta:
+    author: "Federico G. Schwindt"
+    enabled: true
+    name: "BASICFIXTURE.yaml"
+    description: Test various things
+  tests:
+    -
+      test_title: UTF-8文字をテストする
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: www.example.com
+              headers:
+                  User-Agent: Foo
+                  Host: www.example.com
+            output:
+              status: 200


### PR DESCRIPTION
Open the yaml files using utf-8 encoding.  Switch to io.open() so
it also works with python 2.