### PR TITLE
Follow symlinks when searching for rules

### DIFF
--- a/ftw/util.py
+++ b/ftw/util.py
@@ -57,7 +57,7 @@ def get_rulesets(ruledir, recurse):
     List of ruleset objects extracted from the yaml directory
     """
     if os.path.isdir(ruledir) and recurse:
-        yaml_files = [y for x in os.walk(ruledir)
+        yaml_files = [y for x in os.walk(ruledir, followlinks=True)
                       for y in glob(os.path.join(x[0], '*.yaml'))]
     elif os.path.isdir(ruledir) and not recurse:
         yaml_files = get_files(ruledir, 'yaml')


### PR DESCRIPTION
That's it, if we pass a directory and we want to recurse on ensure
that yaml files inside symlinks to directories are also included.