### PR TITLE
Basic build for Docker (Work in Progress)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,13 @@
-FROM python:2.7
+FROM python:3-alpine
+# FROM python:2.7-alpine # for 1.2.0
+
+RUN apk add git g++ 
+# g++ required to build Brotli
+
+RUN git clone https://github.com/coreruleset/ftw.git /opt/ftw
+
+WORKDIR /opt/ftw
+# RUN git checkout tags/1.2.0 && pip install -r requirements.txt
+RUN git checkout master && pip install -r requirements.txt
+
+CMD [/bin/bash] # py.test -s -v test/test_default.py --ruledir=test/yaml


### PR DESCRIPTION
Builds the image successfully thus far. The container drops into a shell for playing around. 

The master branch complains about the unrecognised ruledir argument and without it says the ruleset fixture isn't found.
The 1.2.0 branch throws an "INTERNALERROR" AssertionError with python3 but seems to run in python2.7. I haven't got the time right now to test further.