### PR TITLE
Add `annotation` parameter that stores meta data for programs which extend FTW

### DIFF
--- a/docs/YAMLFormat.md
+++ b/docs/YAMLFormat.md
@@ -76,6 +76,28 @@ name
 
 *Note: The name specified here is used as part of the test execution name, in conjunction with the test_title.
 
+annotation
+----
+**Description**: Arbitrary meta data that can be used by programs that extend FTW.
+
+**Syntax:** ```annotation: "<object of any type>"```
+
+**Example Usage:**
+
+```
+annotation:
+    test-sets: ["test-setA", "test-setX"]
+```
+
+**Default Value:** ""
+
+**Scope:** Metadata
+
+**Added Version:** TBF
+
+*Note: This field itself has no effect on FTW.
+However, programs that extend the FTW can use this field to embed arbitrary metadata in each test file in a format they define.
+
 Tests Parameters
 ================
 The tests area is made up of multiple tests. Each test contains Stages and an optional rule_id. Within the Stage there is additional information that is outlined in Stage Parameters
@@ -123,6 +145,30 @@ desc
 **Added Version:** -
 
 *Note: this keyword isn't mandatory, and not part of the structure of test case, ftw doesn't use it*
+
+annotation
+----
+**Description**: Arbitrary meta data that can be used by programs that extend FTW.
+
+**Syntax:** ```annotation: "<object of any type>"```
+
+**Example Usage:**
+
+```
+annotation:
+    skip:
+        runtime:
+            is: modsec3-nginx
+```
+
+**Default Value:** ""
+
+**Scope:** Tests
+
+**Added Version:** TBF
+
+*Note: This field itself has no effect on FTW.
+However, programs that extend the FTW can use this field to embed arbitrary metadata per test case in a format they define.
 
 Stage Parameters
 ================

--- a/ftw/ruleset.py
+++ b/ftw/ruleset.py
@@ -155,6 +155,9 @@ class Test(object):
         self.enabled = True
         if 'enabled' in self.test_dict:
             self.enabled = self.test_dict['enabled']
+        self.annotation = None
+        if 'annotation' in self.test_dict:
+            self.annotation = self.test_dict['annotation']
 
     def build_stages(self):
         """
@@ -175,6 +178,9 @@ class Ruleset(object):
         self.author = self.meta['author']
         self.description = self.meta['description']
         self.enabled = self.meta['enabled']
+        self.annotation = None
+        if 'annotation' in self.meta:
+            self.annotation = self.meta['annotation']
         self.tests = self.extract_tests() if self.enabled else []
 
     def extract_tests(self):


### PR DESCRIPTION
Hi FTW team. Thanks so much for your great product! It's helping us to improve the security of our application.

In this PR, I'd like to propose to add a new parameter, `annotation` in the YAML file. I would like to ask your opinion, or ask you to merge the PR if it looks good.

### Short description of what `annotation` is

As the updated YAMLFormat.md describes, `annotation` stores arbitrary data so that external programs which extend FTW, such as [CRS_Tets.py of coreruleset](https://github.com/coreruleset/coreruleset/blob/v3.4/dev/tests/regression/CRS_Tests.py), can embed their own data in the format they define. 

### Why `annotation` is useful

This allows external programs that extend FTW to control the test flow based on their program-specific settings such as skipping tests. Example usage is as follows.

Example: skip tests based on the `runtime` in [the regression test of the coreruleset](https://github.com/coreruleset/coreruleset/blob/v3.4/dev/tests/regression/CRS_Tests.py). In this example, `runtime` is the concept of the CRS test, not of FTW. So, skipping a test case based on it can be handled only by the CRS side.  
```yaml
test_title: 920100-14
desc: Invalid HTTP Request Line (920100) - Test 3 from old modsec regressions
annotation:
  skip:
    runtime:
      is: modsec3-nginx
      reason: The invalid HTTP method is rejected by Nginx without WAF
```

Then, the test runner of the CRS can implement its own skip mechanism like this
```python
def test_crs(ruleset, test, logchecker_obj, config):  # note that `config` is the concept of the CRS regression test, not of FTW.
    runner = testrunner.TestRunner()
    if test.annotation and 'skip' in test.annotation:
        if skips_test(test.annotation['skip'], config):
            pytest.skip('Skipped due to the skip condition.')
    for stage in test.stages:
        runner.run_stage(stage, logchecker_obj)
```

Another possible use case.
```yaml
test_title: 920100-14
desc: Invalid HTTP Request Line (920100) - Test 3 from old modsec regressions
annotation:
  test-scenario: ["apache2-tests"] 
```

### Motivation

FTW can be extended by external programs which use FTW as a library, just as [the regression test of the coreruleset](https://github.com/coreruleset/coreruleset/blob/v3.4/dev/tests/regression/CRS_Tests.py) does.
Such program often introduces a their own config system. CRS introduces [a config to switch the ModSecurity implementations](https://github.com/coreruleset/coreruleset/blob/v3.4/dev/tests/regression/config.ini).

I guess it's common demand to control the test cases based on their own configuration. In my case as an example, I wanted to skip some test cases on Nginx and Envoy, on which I implemented my own WAF. 

### Design Discussion

Q: Why do you expect external applications to control the test flow, instead of implementing actual use cases such as skipping tests in FTW?  
A: Because a user will want to fine-grained control based on the config or additional CLI parameters the external application provides. FTW side doesn't know any application-side concepts, such as whether the CLI parameter for the CRS test is `modsec2-apache` or `modsec3-nginx`. Thus, `annotation` can be used to delegate the responsibility to external applications that extend the FTW, just as the FTW delegates the logging method to them. As a side note, it is also possible to introduce new concepts into FTW, such as "configchecker_obj" to reference application-specific settings, but `annotation` is a simpler change and helps to keep FTW as a general framework.

### Possible future work

This PR adds `annotation` parameter only to `Test` and `RuleSet`. However, if you add `annotation` to `Output` as well, a program which extends FTW can implement the conditional output test discussed in #19

```yaml
output:
  status: [200, 400]
  annotation:
    conditional:
    - log_contains: id "1234"
      cond:
        runtime:
          is: apache2-modsec
```

### Reference

Here are two commits from my fork of CRS that implement a feature to skip tests on modsec3-nginx or modsec2-apache.
- Skip test: https://github.com/nullpo-head/coreruleset/commit/fc048f54c69fe5af97d02e7d6dda94147c89abed
- Example yaml: https://github.com/nullpo-head/coreruleset/commit/c92a7f6e5c11bdda8d80e4aafd23a66ef8b66d20