### PR TITLE
docs: change to use YAML literals instead of lists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install requirements

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,11 @@ on: [push, pull_request]
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            setup.py
       - name: Install requirements
         run: |
           python -m pip install -r requirements.txt

--- a/docs/YAMLFormat.md
+++ b/docs/YAMLFormat.md
@@ -284,26 +284,26 @@ version
 
 data
 ----
-**Description**: The optional data portion of the HTTP request. Typically these are provided with the content-type header. Data can be provided as a string or as a YAML list.
+**Description**: The optional data portion of the HTTP request. Typically these are provided with the content-type header. Data can be provided as a string (if one liner) or as a [YAML literal](https://yaml.org/spec/1.2.2/#812-literal-style).
 
-**Syntax:** ```data: "<string|YAML list>"```
+**Syntax:** ```data: "<string|YAML literal>"```
 
 **Example Usage (string):** ```data: "xyz=123"``
 
-**Example Usage (list):**
+**Example Usage (YAML literal):**
 ```
-  data:
-    - "----------397236876"
-    - "Content-Disposition: form-data; name=\"text\";"
-    - ""
-    - "test default"
-    - "----------397236876"
-    - "Content-Disposition: form-data; name=\"file1\"; filename=\"a.txt\""
-    - "Content-Type: text/plain"
-    - ""
-    - "Content of a.txt."
-    - ""
-    - "----------397236876--"
+  data: |
+    ----------397236876
+    Content-Disposition: form-data; name="text";
+    
+    test default
+    ----------397236876
+    Content-Disposition: form-data; name="file1"; filename="a.txt"
+    Content-Type: text/plain
+    
+    Content of a.txt.
+    
+    ----------397236876--
 ```
 
 **Default Value:** ""
@@ -312,6 +312,7 @@ data
 
 **Added Version:** 0.1
 
+*Note: prefer YAML literal if you need multi-line strings.
 *Note: literals \r and \n will be replaced be replaced with CRLF when stop_magic is on.*
 *Note: if urlencoded content-type header is provided and parameters aren't in name=value form, data will be made empty, unless stop_magic is on.*
 


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

The string list format should be deprecated in favor of the more YAML friendly literal.