### PR TITLE
fix: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: ci
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
 
@@ -13,9 +16,9 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install requirements

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,15 +4,18 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
       with:
         python-version: '3.x'
     - name: Install dependencies


### PR DESCRIPTION
## what

- pin `actions/checkout` and `actions/setup-python` to commit SHAs instead of mutable `v2` tags
- add explicit `permissions: contents: read` to all workflows

## why

- unpinned actions reference mutable tags that can be moved by upstream maintainers or attackers
- publish.yml handles PyPI credentials (TWINE_USERNAME/PASSWORD) and was using unpinned actions — a supply chain attack could exfiltrate secrets
- explicit permissions follow the principle of least privilege

## refs

- [GitHub docs: security hardening for GitHub Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions)